### PR TITLE
commitをグループ単位にまとめる

### DIFF
--- a/lib/oxidized_mix/oxidized/cli.rb
+++ b/lib/oxidized_mix/oxidized/cli.rb
@@ -5,6 +5,8 @@ module OxidizedMix
   module Oxidized
     # Util modules
     module CLIUtil
+      DEFAULT_THREADS = 5
+
       attr_reader :extra_config
 
       private


### PR DESCRIPTION
## やりたいこと

oxidized デフォルトでは、デバイス単位でcommitされる。
commit historyが長くなるので、グループごとに1 commitにしたい。

### ついでの修正

- thread 数のデフォルト定義を忘れていた